### PR TITLE
Refactoring random numbers

### DIFF
--- a/src/gpuocean/SWEsimulators/KP07.py
+++ b/src/gpuocean/SWEsimulators/KP07.py
@@ -288,6 +288,7 @@ class KP07(Simulator.Simulator):
         for i in range(0, n):        
             local_dt = np.float32(min(self.dt, t_end-i*self.dt))
             
+
             wind_stress_t = np.float32(self.update_wind_stress(self.kp07_kernel, self.swe_2D))
             
             if (local_dt <= 0.0):
@@ -375,8 +376,13 @@ class KP07(Simulator.Simulator):
         return self.t
     
     
-    
-
-    def downloadBathymetry(self):
-        return self.bathymetry.download(self.gpu_stream)
-
+    def downloadBathymetry(self, interior_domain_only=False):
+        Bi, Bm = self.bathymetry.download(self.gpu_stream)
+        
+        if interior_domain_only:
+            Bi = Bi[self.interior_domain_indices[2]:self.interior_domain_indices[0]+1,  
+               self.interior_domain_indices[3]:self.interior_domain_indices[1]+1] 
+            Bm = Bm[self.interior_domain_indices[2]:self.interior_domain_indices[0],  
+               self.interior_domain_indices[3]:self.interior_domain_indices[1]]
+               
+        return [Bi, Bm]

--- a/src/gpuocean/SWEsimulators/OceanStateNoise.py
+++ b/src/gpuocean/SWEsimulators/OceanStateNoise.py
@@ -33,7 +33,7 @@ from pycuda.curandom import XORWOWRandomNumberGenerator
 
 import gc
 
-from gpuocean.utils import Common, config
+from gpuocean.utils import Common, RandomNumbers, config
 from gpuocean.SWEsimulators import FBL, CTCS
 
 class OceanStateNoise(object):
@@ -75,8 +75,6 @@ class OceanStateNoise(object):
         
         # Make sure that all variables initialized within ifs are defined
         self.random_numbers = None
-        self.rng = None
-        self.seed = None
         self.host_seed = None
         
         self.gpu_ctx = gpu_ctx
@@ -125,29 +123,22 @@ class OceanStateNoise(object):
         self.rand_nx = np.int32(self.coarse_nx + 2*self.rand_ghost_cells_x)
         self.rand_ny = np.int32(self.coarse_ny + 2*self.rand_ghost_cells_y)
 
+        self.rng = RandomNumbers.RandomNumbers(gpu_ctx, self.gpu_stream, 
+                                               self.rand_nx, self.rand_ny, 
+                                               use_lcg=self.use_lcg, xorwow_seed=xorwow_seed,
+                                               block_width=block_width, block_height=block_height)
+
         # Since normal distributed numbers are generated in pairs, we need to store half the number of
         # of seed values compared to the number of random numbers.
+        # Kept in this class due to the selfwritten CPU versions of the random number generators only
         self.seed_ny = np.int32(self.rand_ny)
         self.seed_nx = np.int32(np.ceil(self.rand_nx/2))
 
         # Generate seed:
-        self.floatMax = 2147483648.0
+        self.floatMax = self.rng.floatMax
         if self.use_lcg:
-            self.host_seed = self.random_state.rand(self.seed_ny, self.seed_nx)*self.floatMax
-            self.host_seed = self.host_seed.astype(np.uint64, order='C')
-        
-        if not self.use_lcg:
-            if xorwow_seed is not None:
-                def set_seeder(N, seed):
-                    seedarr = pycuda.gpuarray.ones_like(pycuda.gpuarray.zeros(N, dtype=np.int32), dtype=np.int32) * seed
-                    return seedarr
-
-                self.rng = XORWOWRandomNumberGenerator( lambda N: set_seeder(N,xorwow_seed))
-            else:
-                self.rng = XORWOWRandomNumberGenerator()
-        else:
-            self.seed = Common.CUDAArray2D(gpu_stream, self.seed_nx, self.seed_ny, 0, 0, self.host_seed, double_precision=True, integers=True)
-        
+            self.host_seed = self.rng.host_seed
+   
         # Constants for the SOAR function:
         self.soar_q0 = np.float32(self.dx/100000)
         if soar_q0 is not None:
@@ -199,6 +190,16 @@ class OceanStateNoise(object):
         self.makePerpendicularKernel = self.kernels.get_function("makePerpendicular")
         self.makePerpendicularKernel.prepare("iiPiPiP")
         
+        
+        self.uniformDistributionKernel = self.kernels.get_function("uniformDistribution")
+        self.uniformDistributionKernel.prepare("iiiPiPi")
+        
+        self.normalDistributionKernel = None
+        if self.use_lcg:
+            self.normalDistributionKernel = self.kernels.get_function("normalDistribution")
+            self.normalDistributionKernel.prepare("iiiPiPi")
+        
+                
         self.uniformDistributionKernel = self.kernels.get_function("uniformDistribution")
         self.uniformDistributionKernel.prepare("iiiPiPi")
         
@@ -287,9 +288,7 @@ class OceanStateNoise(object):
      
     def cleanUp(self):
         if self.rng is not None:
-            self.rng = None
-        if self.seed is not None:
-            self.seed.release()
+            self.rng.cleanUp()
         if self.random_numbers is not None:
             self.random_numbers.release()
         if self.perpendicular_random_numbers is not None:
@@ -316,18 +315,10 @@ class OceanStateNoise(object):
                    block_width=block_width, block_height=block_height)
 
     def getSeed(self):
-        assert(self.use_lcg), "getSeed is only valid if LCG is used as pseudo-random generator."
-        
-        return self.seed.download(self.gpu_stream)
+        return self.rng.getSeed()
     
     def resetSeed(self):
-        assert(self.use_lcg), "resetSeed is only valid if LCG is used as pseudo-random generator."
-
-        # Generate seed:
-        self.floatMax = 2147483648.0
-        self.host_seed = self.random_state.rand(self.seed_ny, self.seed_nx)*self.floatMax
-        self.host_seed = self.host_seed.astype(np.uint64, order='C')
-        self.seed.upload(self.gpu_stream, self.host_seed)
+        self.rng.resetSeed()
 
     def getRandomNumbers(self):
         return self.random_numbers.download(self.gpu_stream)
@@ -342,36 +333,14 @@ class OceanStateNoise(object):
         return self.reduction_buffer.download(self.gpu_stream)
     
     def generateNormalDistribution(self):
-        if not self.use_lcg:
-            self.rng.fill_normal(self.random_numbers.data, stream=self.gpu_stream)
-        else:
-            self.normalDistributionKernel.prepared_async_call(self.global_size_random_numbers, self.local_size, self.gpu_stream,
-                                                              self.seed_nx, self.seed_ny,
-                                                              self.rand_nx,
-                                                              self.seed.data.gpudata, self.seed.pitch,
-                                                              self.random_numbers.data.gpudata, self.random_numbers.pitch)
+        self.rng.generateNormalDistribution(self.random_numbers)
     
     def generateNormalDistributionPerpendicular(self):
-        if not self.use_lcg:
-            self.rng.fill_normal(self.perpendicular_random_numbers.data, stream=self.gpu_stream)
-        else:
-            self.normalDistributionKernel.prepared_async_call(self.global_size_random_numbers, self.local_size, self.gpu_stream,
-                                                              self.seed_nx, self.seed_ny,
-                                                              self.rand_nx,
-                                                              self.seed.data.gpudata, self.seed.pitch,
-                                                              self.perpendicular_random_numbers.data.gpudata, self.perpendicular_random_numbers.pitch)
+        self.rng.generateNormalDistribution(self.perpendicular_random_numbers)
 
     def generateUniformDistribution(self):
-        # Call kernel -> new random numbers
-        if not self.use_lcg:
-            self.rng.fill_uniform(self.random_numbers.data, stream=self.gpu_stream)
-        else:
-            self.uniformDistributionKernel.prepared_async_call(self.global_size_random_numbers, self.local_size, self.gpu_stream,
-                                                               self.seed_nx, self.seed_ny,
-                                                               self.rand_nx,
-                                                               self.seed.data.gpudata, self.seed.pitch,
-                                                               self.random_numbers.data.gpudata, self.random_numbers.pitch)
-
+        self.rng.generateUniformDistribution(self.random_numbers)
+        
     def perturbSim(self, sim, q0_scale=1.0, update_random_field=True, 
                    perturbation_scale=1.0, perpendicular_scale=0.0,
                    align_with_cell_i=None, align_with_cell_j=None, stream=None):

--- a/src/gpuocean/gpu_kernels/ocean_noise.cu
+++ b/src/gpuocean/gpu_kernels/ocean_noise.cu
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "common.cu"
+#include "random_number_generators.cu"
 
 texture<float, cudaTextureType2D> coriolis_f_tex;
 texture<float, cudaTextureType2D> angle_tex;
@@ -71,133 +72,6 @@ inline float2 getNorth(const int i, const int j, const int nx_, const int ny_) {
 //        the textures are defined to avoid compilation errors!
 
 
-
-
-
-/**
-  *  Generates two uniform random numbers based on the ANSIC Linear Congruential 
-  *  Generator.
-  */
-__device__ float2 ansic_lcg(unsigned long long* seed_ptr) {
-    unsigned long long seed = (*seed_ptr);
-    double denum = 2147483648.0;
-    unsigned long long modulo = 2147483647;
-
-    seed = ((seed * 1103515245) + 12345) % modulo; //% 0x7fffffff;
-    float u1 = seed / denum;
-
-    seed = ((seed * 1103515245) + 12345) % modulo; //0x7fffffff;
-    float u2 = seed / denum;
-
-    (*seed_ptr) = seed;
-
-    float2 out;
-    out.x = u1;
-    out.y = u2;
-
-    return out;
-    //return make_float2(u1, u2);
-}
-
-/**
-  *  Generates two random numbers, drawn from a normal distribtion with mean 0 and
-  *  variance 1. Based on the Box Muller transform.
-  */
-__device__ float2 boxMuller(float2 u) {
-    float r = sqrt(-2.0f*log(u.x));
-    float n1 = r*cospi(2*u.y);
-    float n2 = r*sinpi(2*u.y);
-
-    float2 out;
-    out.x = n1;
-    out.y = n2;
-    return out;
-}
-
-/**
-  * Kernel that generates uniform random numbers.
-  */
-extern "C" {
-__global__ void uniformDistribution(
-        // Size of data
-        int seed_nx_, int seed_ny_,        
-        int random_nx_,
-        
-        //Data
-        unsigned long long* seed_ptr_, int seed_pitch_,
-        float* random_ptr_, int random_pitch_
-    ) {
-
-    //Index of cell within domain
-    const int ti = (blockDim.x * blockIdx.x) + threadIdx.x;
-    const int tj = (blockDim.y * blockIdx.y) + threadIdx.y;
-
-    // Each thread computes and writes two uniform numbers.
-
-    if ((ti < seed_nx_) && (tj < seed_ny_)) {
-    
-        //Compute pointer to current row in the U array
-        unsigned long long* const seed_row = (unsigned long long*) ((char*) seed_ptr_ + seed_pitch_*tj);
-        float* const random_row = (float*) ((char*) random_ptr_ + random_pitch_*tj);
-        
-        unsigned long long seed = seed_row[ti];
-        float2 u = ansic_lcg(&seed);
-
-        seed_row[ti] = seed;
-
-        if (2*ti + 1 < random_nx_) {
-            random_row[2*ti    ] = u.x;
-            random_row[2*ti + 1] = u.y;
-        }
-        else if (2*ti == random_nx_) {
-            random_row[2*ti    ] = u.x;
-        }
-    }
-}
-} // extern "C"
-
-/**
-  * Kernel that generates normal distributed random numbers with mean 0 and variance 1.
-  */
-extern "C" {
-__global__ void normalDistribution(
-        // Size of data
-        int seed_nx_, int seed_ny_,
-        int random_nx_,               // random_ny_ is equal to seed_ny_
-        
-        //Data
-        unsigned long long* seed_ptr_, int seed_pitch_, // size [seed_nx, seed_ny]
-        float* random_ptr_, int random_pitch_           // size [random_nx, seed_ny]
-    ) {
-    
-    //Index of cell within domain
-    const int ti = (blockDim.x * blockIdx.x) + threadIdx.x;
-    const int tj = (blockDim.y * blockIdx.y) + threadIdx.y;
-
-    // Each thread computes and writes two uniform numbers.
-
-    if ((ti < seed_nx_) && (tj < seed_ny_)) {
-    
-        //Compute pointer to current row in the U array
-        unsigned long long* const seed_row = (unsigned long long*) ((char*) seed_ptr_ + seed_pitch_*tj);
-        float* const random_row = (float*) ((char*) random_ptr_ + random_pitch_*tj);
-        
-        unsigned long long seed = seed_row[ti];
-        float2 r = ansic_lcg(&seed);
-        float2 u = boxMuller(r);
-
-        seed_row[ti] = seed;
-
-        if (2*ti + 1 < random_nx_) {
-            random_row[2*ti    ] = u.x;
-            random_row[2*ti + 1] = u.y;
-        }
-        else if (2*ti == random_nx_) {
-            random_row[2*ti    ] = u.x;
-        }
-    }
-}
-} // extern "C"
 
 /**
   * Kernel that takes two random vectors (xi, nu) as input, and make nu perpendicular to xi 

--- a/src/gpuocean/gpu_kernels/random_number_generators.cu
+++ b/src/gpuocean/gpu_kernels/random_number_generators.cu
@@ -24,7 +24,7 @@ __device__ float2 ansic_lcg(unsigned long long* seed_ptr) {
     return out;
     //return make_float2(u1, u2);
 }
-__device__ float2 rand_u(unsigned long long* seed_ptr) {
+__device__ float2 rand_uniform(unsigned long long* seed_ptr) {
     return ansic_lcg(seed_ptr);
 }
 
@@ -42,7 +42,8 @@ __device__ float2 boxMuller(float2 u) {
     out.y = n2;
     return out;
 }
-__device__ float2 rand_n(float2 u) {
+__device__ float2 rand_normal(unsigned long long* seed_ptr) {
+    float2 u = ansic_lcg(seed_ptr);
     return boxMuller(u);
 }
 

--- a/src/gpuocean/gpu_kernels/random_number_generators.cu
+++ b/src/gpuocean/gpu_kernels/random_number_generators.cu
@@ -1,0 +1,132 @@
+
+
+/**
+  *  Generates two uniform random numbers based on the ANSIC Linear Congruential 
+  *  Generator.
+  */
+__device__ float2 ansic_lcg(unsigned long long* seed_ptr) {
+    unsigned long long seed = (*seed_ptr);
+    double denum = 2147483648.0;
+    unsigned long long modulo = 2147483647;
+
+    seed = ((seed * 1103515245) + 12345) % modulo; //% 0x7fffffff;
+    float u1 = seed / denum;
+
+    seed = ((seed * 1103515245) + 12345) % modulo; //0x7fffffff;
+    float u2 = seed / denum;
+
+    (*seed_ptr) = seed;
+
+    float2 out;
+    out.x = u1;
+    out.y = u2;
+
+    return out;
+    //return make_float2(u1, u2);
+}
+__device__ float2 rand_u(unsigned long long* seed_ptr) {
+    return ansic_lcg(seed_ptr);
+}
+
+/**
+  *  Generates two random numbers, drawn from a normal distribtion with mean 0 and
+  *  variance 1. Based on the Box Muller transform.
+  */
+__device__ float2 boxMuller(float2 u) {
+    float r = sqrt(-2.0f*log(u.x));
+    float n1 = r*cospi(2*u.y);
+    float n2 = r*sinpi(2*u.y);
+
+    float2 out;
+    out.x = n1;
+    out.y = n2;
+    return out;
+}
+__device__ float2 rand_n(float2 u) {
+    return boxMuller(u);
+}
+
+/**
+  * Kernel that generates uniform random numbers.
+  */
+extern "C" {
+__global__ void uniformDistribution(
+        // Size of data
+        int seed_nx_, int seed_ny_,        
+        int random_nx_,
+        
+        //Data
+        unsigned long long* seed_ptr_, int seed_pitch_,
+        float* random_ptr_, int random_pitch_
+    ) {
+
+    //Index of cell within domain
+    const int ti = (blockDim.x * blockIdx.x) + threadIdx.x;
+    const int tj = (blockDim.y * blockIdx.y) + threadIdx.y;
+
+    // Each thread computes and writes two uniform numbers.
+
+    if ((ti < seed_nx_) && (tj < seed_ny_)) {
+    
+        //Compute pointer to current row in the U array
+        unsigned long long* const seed_row = (unsigned long long*) ((char*) seed_ptr_ + seed_pitch_*tj);
+        float* const random_row = (float*) ((char*) random_ptr_ + random_pitch_*tj);
+        
+        unsigned long long seed = seed_row[ti];
+        float2 u = ansic_lcg(&seed);
+
+        seed_row[ti] = seed;
+
+        if (2*ti + 1 < random_nx_) {
+            random_row[2*ti    ] = u.x;
+            random_row[2*ti + 1] = u.y;
+        }
+        else if (2*ti == random_nx_) {
+            random_row[2*ti    ] = u.x;
+        }
+    }
+}
+} // extern "C"
+
+/**
+  * Kernel that generates normal distributed random numbers with mean 0 and variance 1.
+  */
+extern "C" {
+__global__ void normalDistribution(
+        // Size of data
+        int seed_nx_, int seed_ny_,
+        int random_nx_,               // random_ny_ is equal to seed_ny_
+        
+        //Data
+        unsigned long long* seed_ptr_, int seed_pitch_, // size [seed_nx, seed_ny]
+        float* random_ptr_, int random_pitch_           // size [random_nx, seed_ny]
+    ) {
+    
+    //Index of cell within domain
+    const int ti = (blockDim.x * blockIdx.x) + threadIdx.x;
+    const int tj = (blockDim.y * blockIdx.y) + threadIdx.y;
+
+    // Each thread computes and writes two uniform numbers.
+
+    if ((ti < seed_nx_) && (tj < seed_ny_)) {
+    
+        //Compute pointer to current row in the U array
+        unsigned long long* const seed_row = (unsigned long long*) ((char*) seed_ptr_ + seed_pitch_*tj);
+        float* const random_row = (float*) ((char*) random_ptr_ + random_pitch_*tj);
+        
+        unsigned long long seed = seed_row[ti];
+        float2 r = ansic_lcg(&seed);
+        float2 u = boxMuller(r);
+
+        seed_row[ti] = seed;
+
+        if (2*ti + 1 < random_nx_) {
+            random_row[2*ti    ] = u.x;
+            random_row[2*ti + 1] = u.y;
+        }
+        else if (2*ti == random_nx_) {
+            random_row[2*ti    ] = u.x;
+        }
+    }
+}
+} // extern "C"

--- a/src/gpuocean/utils/RandomNumbers.py
+++ b/src/gpuocean/utils/RandomNumbers.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+
+"""
+This software is part of GPU Ocean. 
+
+Copyright (C) 2018, 2019, 2024  SINTEF Digital
+Copyright (C) 2018, 2019 Norwegian Meteorological Institute
+
+This class implements some simple random number generators on the GPU
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import numpy as np
+
+import pycuda.gpuarray 
+import pycuda.driver as cuda
+from pycuda.curandom import XORWOWRandomNumberGenerator
+import gc
+
+from gpuocean.utils import Common
+
+
+
+class RandomNumbers(object):
+    """
+    Class for generating random numbers within GPU Ocean.
+    
+    Arrays for holding the random numbers must be held by other objects, and only objects related to 
+    the random number generation itself is held by this class.
+    """
+
+    def __init__(self, gpu_ctx, gpu_stream, nx, ny,
+                 use_lcg=False,
+                 xorwow_seed=None,
+                 block_width=16, block_height=16):
+        """
+        Class for generating random numbers within GPU Ocean.
+        
+        (ny, nx): shape of the random number array that will be generated
+        use_lcg: LCG is a linear algorithm for generating a serie of pseudo-random numbers
+        angle: Angle of rotation from North to y-axis as a texture (cuda.Array) or numpy array
+        (block_width, block_height): The size of each GPU block
+        """
+        
+        self.use_lcg = use_lcg
+        self.gpu_stream = gpu_stream
+
+        # Set numpy random state
+        self.random_state = np.random.RandomState()
+        
+        # Make sure that all variables initialized within ifs are defined
+        self.rng = None
+        self.seed = None
+        self.host_seed = None
+
+        self.nx = np.int32(nx)
+        self.ny = np.int32(ny)
+
+        # Since normal distributed numbers are generated in pairs, we need to store half the number of
+        # of seed values compared to the number of random numbers. 
+        # This split is in x-direction, and the dimension in y is kept as is
+        self.seed_ny = np.int32(self.ny)
+        self.seed_nx = np.int32(np.ceil(self.nx/2))
+
+        # Generate seed:
+        self.floatMax = 2147483648.0
+        if self.use_lcg:
+            self.host_seed = self.random_state.rand(self.seed_ny, self.seed_nx)*self.floatMax
+            self.host_seed = self.host_seed.astype(np.uint64, order='C')
+        
+        if not self.use_lcg:
+            if xorwow_seed is not None:
+                def set_seeder(N, seed):
+                    seedarr = pycuda.gpuarray.ones_like(pycuda.gpuarray.zeros(N, dtype=np.int32), dtype=np.int32) * seed
+                    return seedarr
+
+                self.rng = XORWOWRandomNumberGenerator( lambda N: set_seeder(N,xorwow_seed))
+            else:
+                self.rng = XORWOWRandomNumberGenerator()
+        else:
+            self.seed = Common.CUDAArray2D(self.gpu_stream, self.seed_nx, self.seed_ny, 0, 0, self.host_seed, double_precision=True, integers=True)
+        
+
+        # Generate kernels
+        self.kernels = gpu_ctx.get_kernel("random_number_generators.cu", \
+                                          defines={'block_width': block_width, 'block_height': block_height, 
+                                                },
+                                          compile_args={
+                                              'options': ["--use_fast_math",
+                                                          "--maxrregcount=32"]
+                                          })
+        
+        # Get CUDA functions and define data types for prepared_{async_}call()
+        # Generate kernels
+        self.uniformDistributionKernel = self.kernels.get_function("uniformDistribution")
+        self.uniformDistributionKernel.prepare("iiiPiPi")
+        
+        self.normalDistributionKernel = None
+        if self.use_lcg:
+            self.normalDistributionKernel = self.kernels.get_function("normalDistribution")
+            self.normalDistributionKernel.prepare("iiiPiPi")
+
+
+         #Compute kernel launch parameters
+        self.local_size = (block_width, block_height, 1)
+        
+        # Launch one thread for each seed, which in turns generates two iid N(0,1)
+        self.global_size_random_numbers = ( \
+                       int(np.ceil(self.seed_nx / float(self.local_size[0]))), \
+                       int(np.ceil(self.seed_ny / float(self.local_size[1]))) \
+                     ) 
+        
+
+    def __del__(self):
+        self.cleanUp()
+     
+    def cleanUp(self):
+        if self.rng is not None:
+            self.rng = None
+        if self.seed is not None:
+            self.seed.release()
+        self.gpu_ctx = None
+        gc.collect()
+        
+
+        
+
+    def getSeed(self):
+        assert(self.use_lcg), "getSeed is only valid if LCG is used as pseudo-random generator."
+        
+        return self.seed.download(self.gpu_stream)
+    
+    def resetSeed(self):
+        assert(self.use_lcg), "resetSeed is only valid if LCG is used as pseudo-random generator."
+
+        # Generate seed:
+        self.host_seed = self.random_state.rand(self.seed_ny, self.seed_nx)*self.floatMax
+        self.host_seed = self.host_seed.astype(np.uint64, order='C')
+        self.seed.upload(self.gpu_stream, self.host_seed)
+
+    def _checkInput(self, random_numbers):
+        assert(isinstance(random_numbers, Common.CUDAArray2D)), "expected random_numbers of type CUDAArray2D but got " + str(type(random_numbers))
+        shape_input = (random_numbers.ny, random_numbers.nx)
+        shape_expected = (self.ny, self.nx)
+        assert(shape_input == shape_expected), "expected random_numbers with shape " +str(shape_expected) + " but got " +str(shape_input)
+
+    def generateNormalDistribution(self, random_numbers):
+        self._checkInput(random_numbers)
+        if not self.use_lcg:
+            self.rng.fill_normal(random_numbers.data, stream=self.gpu_stream)
+        else:
+            self.normalDistributionKernel.prepared_async_call(self.global_size_random_numbers, self.local_size, self.gpu_stream,
+                                                              self.seed_nx, self.seed_ny,
+                                                              self.nx,
+                                                              self.seed.data.gpudata, self.seed.pitch,
+                                                              random_numbers.data.gpudata, random_numbers.pitch)
+    
+    def generateUniformDistribution(self, random_numbers):
+        self._checkInput(random_numbers)
+        if not self.use_lcg:
+            self.rng.fill_uniform(random_numbers.data, stream=self.gpu_stream)
+        else:
+            self.uniformDistributionKernel.prepared_async_call(self.global_size_random_numbers, self.local_size, self.gpu_stream,
+                                                               self.seed_nx, self.seed_ny,
+                                                               self.nx,
+                                                               self.seed.data.gpudata, self.seed.pitch,
+                                                               random_numbers.data.gpudata, random_numbers.pitch)

--- a/test/random_numbers.py
+++ b/test/random_numbers.py
@@ -30,6 +30,7 @@ import xmlrunner
 # $ sudo easy_install unittest-xml-reporting
 
 #import testUtils
+from stochastic.RandomNumbers_test import RandomNumbersTest
 from stochastic.OceanStateNoise_test import OceanStateNoiseTest
 from stochastic.OceanStateNoise_LCG_test import OceanStateNoiseLCGTest
 from stochastic.RandThroughOceanNoise_test import RandThroughOceanNoiseTest
@@ -62,12 +63,13 @@ if (jenkins):
 # Define the tests that will be part of our test suite:
 test_classes_to_run = None
 if tests == 0:
-    test_classes_to_run = [RandThroughOceanNoiseTest, 
+    test_classes_to_run = [RandomNumbersTest,
+                           RandThroughOceanNoiseTest, 
                            OceanStateNoiseTest,
                            RandThroughOceanNoiseLCGTest,
                            OceanStateNoiseLCGTest]
 elif tests == 1:
-    test_classes_to_run = []
+    test_classes_to_run = [RandomNumbersTest]
 elif tests == 2:
     test_classes_to_run = [RandThroughOceanNoiseTest]
 elif tests == 3:

--- a/test/random_numbers.py
+++ b/test/random_numbers.py
@@ -32,13 +32,14 @@ import xmlrunner
 #import testUtils
 from stochastic.OceanStateNoise_test import OceanStateNoiseTest
 from stochastic.OceanStateNoise_LCG_test import OceanStateNoiseLCGTest
-from stochastic.RandomNumbers_test import RandomNumbersTest
-from stochastic.RandomNumbers_LCG_test import RandomNumbersLCGTest
+from stochastic.RandThroughOceanNoise_test import RandThroughOceanNoiseTest
+from stochastic.RandThroughOceanNoise_LCG_test import RandThroughOceanNoiseLCGTest
 
 def printSupportedTests():
     print ("Supported tests:")
-    print ("0: All, 1: RandomNumbers, 2: OceanStateNoise, " +
-           "3: RandomNumbersLCGTest, 4: OceanStateNoiseLCGTest")
+    print ("0: All, 1: RandomNumbers, " +
+           "2: RandThroughOceanNoiseTest, 3: OceanStateNoise, " +
+           "4: RandThroughOceanNoiseLCGTest, 5: OceanStateNoiseLCGTest")
 
 
 if (len(sys.argv) < 2):
@@ -61,17 +62,19 @@ if (jenkins):
 # Define the tests that will be part of our test suite:
 test_classes_to_run = None
 if tests == 0:
-    test_classes_to_run = [RandomNumbersTest, 
+    test_classes_to_run = [RandThroughOceanNoiseTest, 
                            OceanStateNoiseTest,
-                           RandomNumbersLCGTest,
+                           RandThroughOceanNoiseLCGTest,
                            OceanStateNoiseLCGTest]
 elif tests == 1:
-    test_classes_to_run = [RandomNumbersTest]
+    test_classes_to_run = []
 elif tests == 2:
-    test_classes_to_run = [OceanStateNoiseTest]
+    test_classes_to_run = [RandThroughOceanNoiseTest]
 elif tests == 3:
-    test_classes_to_run = [RandomNumbersLCGTest]
+    test_classes_to_run = [OceanStateNoiseTest]
 elif tests == 4:
+    test_classes_to_run = [RandThroughOceanNoiseLCGTest]
+elif tests == 5:
     test_classes_to_run = [OceanStateNoiseLCGTest]
 else:
     print ("Error: " + str(tests) + " is not a supported test number...")

--- a/test/stochastic/RandThroughOceanNoise_LCG_test.py
+++ b/test/stochastic/RandThroughOceanNoise_LCG_test.py
@@ -8,10 +8,10 @@ import pycuda.driver as cuda
 from testUtils import *
 
 from gpuocean.utils import Common
-from stochastic.RandomNumbers_test import RandomNumbersTest
+from stochastic.RandThroughOceanNoise_test import RandThroughOceanNoiseTest
 
 
-class RandomNumbersLCGTest(RandomNumbersTest):
+class RandThroughOceanNoiseLCGTest(RandThroughOceanNoiseTest):
     """
     Executing all the same tests as RandomNumbersTest, but
     using the LCG algorithm for random numbers.

--- a/test/stochastic/RandThroughOceanNoise_test.py
+++ b/test/stochastic/RandThroughOceanNoise_test.py
@@ -4,7 +4,8 @@ This software is part of GPU Ocean.
 
 Copyright (C) 2018 SINTEF Digital
 
-This python module implements regression tests for generation of random numbers.
+This python module implements regression tests for generation of random 
+numbers through the OceanNoise class.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/test/stochastic/RandThroughOceanNoise_test.py
+++ b/test/stochastic/RandThroughOceanNoise_test.py
@@ -34,7 +34,7 @@ from gpuocean.SWEsimulators.OceanStateNoise import *
 from stochastic.OceanStateNoise_parent import OceanStateNoiseTestParent
 
 
-class RandomNumbersTest(OceanStateNoiseTestParent):
+class RandThroughOceanNoiseTest(OceanStateNoiseTestParent):
         
     def test_random_uniform(self):
         self.create_large_noise()

--- a/test/stochastic/RandThroughOceanNoise_test.py
+++ b/test/stochastic/RandThroughOceanNoise_test.py
@@ -172,8 +172,8 @@ class RandThroughOceanNoiseTest(OceanStateNoiseTestParent):
             assert2DListNotAlmostEqual(self, uniform_seed.tolist(), init_seed.tolist(), tol, "test_seed_diff, uniform vs init_seed")
             assert2DListNotAlmostEqual(self, uniform_seed.tolist(), normal_seed.tolist(), tol, "test_seed_diff, uniform vs normal_seed")
         else:
-            self.assertIsNone(self.noise.seed)
-            self.assertIsNone(self.noise.host_seed)
+            self.assertIsNone(self.noise.rng.seed)
+            self.assertIsNone(self.noise.rng.host_seed)
             self.failUnlessRaises(AssertionError, self.noise.getSeed)
             self.failUnlessRaises(AssertionError, self.noise.resetSeed)
            

--- a/test/stochastic/RandomNumbers_test.py
+++ b/test/stochastic/RandomNumbers_test.py
@@ -37,8 +37,8 @@ class RandomNumbersTest(unittest.TestCase):
         self.gpu_ctx = Common.CUDAContext()
         self.gpu_stream = cuda.Stream()
         
-        self.nx = 256
-        self.ny = 256
+        self.nx = 512
+        self.ny = 512
         
         self.rng = None
         self.random_numbers = None

--- a/test/stochastic/RandomNumbers_test.py
+++ b/test/stochastic/RandomNumbers_test.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""
+This software is part of GPU Ocean. 
+
+Copyright (C) 2018, 2024 SINTEF Digital
+
+This python module implements regression tests for generation of random numbers.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import unittest
+import time
+import numpy as np
+import sys
+import gc
+import pycuda.driver as cuda
+
+from testUtils import *
+
+from gpuocean.utils import Common, RandomNumbers
+
+class RandomNumbersTest(unittest.TestCase):
+
+    def setUp(self):
+        self.gpu_ctx = Common.CUDAContext()
+        self.gpu_stream = cuda.Stream()
+        
+        self.nx = 256
+        self.ny = 256
+        
+        self.rng = None
+        self.random_numbers = None
+                
+        self.floatMax = 2147483648.0
+
+        
+    def tearDown(self):
+        if self.rng is not None:
+            self.rng.cleanUp()
+            del self.rng
+        if self.random_numbers is not None:
+            self.random_numbers.release()
+        if self.gpu_ctx is not None:
+            self.assertEqual(sys.getrefcount(self.gpu_ctx), 2)
+            self.gpu_ctx = None
+   
+        gc.collect()
+            
+    def create_rng(self, lcg):
+        self.rng = RandomNumbers.RandomNumbers(self.gpu_ctx, self.gpu_stream,
+                                               self.nx, self.ny,
+                                               use_lcg=lcg)
+        self.random_numbers = Common.CUDAArray2D(self.gpu_stream, self.nx, self.ny, 0, 0,
+                                                np.zeros((self.ny, self.nx), dtype=np.float32))
+
+    #########################################################################
+    ### Tests 
+    #########################################################################
+    def random_uniform(self, lcg):
+        self.create_rng(lcg)
+        self.rng.generateUniformDistribution(self.random_numbers)
+        U = self.random_numbers.download(self.gpu_stream)
+
+        mean = np.mean(U)
+        var = np.var(U)
+
+        # Check the mean and var with very low accuracy.
+        # Gives error if the distribution is way off
+        self.assertLess(np.abs(mean - 0.5), 0.005)
+        self.assertLess(np.abs(var - 1/12), 0.001)
+        
+    def test_random_uniform_lcg(self):
+        self.random_uniform(lcg=True)
+
+    def test_random_uniform_curand(self):
+        self.random_uniform(lcg=False)
+
+    def random_normal(self, lcg):
+        self.create_rng(lcg)
+        self.rng.generateNormalDistribution(self.random_numbers)
+        U = self.random_numbers.download(self.gpu_stream)
+
+        mean = np.mean(U)
+        var = np.var(U)
+
+        # Check the mean and var with very low accuracy.
+        # Gives error if the distribution is way off
+        self.assertLess(np.abs(mean), 0.01)
+        self.assertLess(np.abs(var - 1.0), 0.01)
+
+    def test_random_normal_lcg(self):
+        self.random_normal(lcg=True)
+
+    def test_random_normal_curand(self):
+        self.random_normal(lcg=False)
+
+
+    def seed_diff(self, lcg):
+        self.create_rng(lcg=lcg)
+        tol = 7
+
+        if lcg:
+            init_seed = self.rng.getSeed()/self.rng.floatMax
+            self.rng.generateNormalDistribution(self.random_numbers)
+            normal_seed = self.rng.getSeed()/self.rng.floatMax
+            assert2DListNotAlmostEqual(self, normal_seed.tolist(), init_seed.tolist(), tol, "test_seed_diff, normal vs init_seed")
+            
+            self.rng.generateUniformDistribution(self.random_numbers)
+            uniform_seed = self.rng.getSeed()/self.floatMax
+            assert2DListNotAlmostEqual(self, uniform_seed.tolist(), init_seed.tolist(), tol, "test_seed_diff, uniform vs init_seed")
+            assert2DListNotAlmostEqual(self, uniform_seed.tolist(), normal_seed.tolist(), tol, "test_seed_diff, uniform vs normal_seed")
+        else:
+            self.assertIsNone(self.rng.seed)
+            self.assertIsNone(self.rng.host_seed)
+            self.failUnlessRaises(AssertionError, self.rng.getSeed)
+            self.failUnlessRaises(AssertionError, self.rng.resetSeed)
+           
+    def test_seed_diff_lcg(self):
+        self.seed_diff(lcg=True)
+    
+    def test_seed_diff_curand(self):
+        self.seed_diff(lcg=False)


### PR DESCRIPTION
Our functionality for generating random numbers (both using our own gpu kernels and the pycuda curand interface) has been hidden with the  `OceanStateNoise` class.
This PR extract the functions for generating uniform and normal distributed numbers into a new `RandomNumbers` class, so that it is easier for other parts of the code base to make use of them as well.

Unit tests are also updated:
`test/random_numbers.py` 