### PR TITLE
Remove dt from sim_args in TutorialDeterministicDrift.ipynb example

### DIFF
--- a/examples/TutorialDeterministicDrift.ipynb
+++ b/examples/TutorialDeterministicDrift.ipynb
@@ -212,7 +212,6 @@
    "source": [
     "sim_args = {\n",
     "    \"gpu_ctx\": gpu_ctx,\n",
-    "    \"dt\": 0.0,\n",
     "     }\n",
     "\n",
     "sim = CDKLM16.CDKLM16(**sim_args, **NetCDFInitialization.removeMetadata(data_args))"


### PR DESCRIPTION
Fixes conflicting dt defintion, as dt is also part of data-args from NetCDFInitialization.