### PR TITLE
Seed for random numbers

### DIFF
--- a/src/gpuocean/utils/RandomNumbers.py
+++ b/src/gpuocean/utils/RandomNumbers.py
@@ -43,7 +43,7 @@ class RandomNumbers(object):
 
     def __init__(self, gpu_ctx, gpu_stream, nx, ny,
                  use_lcg=False,
-                 xorwow_seed=None,
+                 xorwow_seed=None, numpy_seed=None,
                  block_width=16, block_height=16):
         """
         Class for generating random numbers within GPU Ocean.
@@ -58,7 +58,7 @@ class RandomNumbers(object):
         self.gpu_stream = gpu_stream
 
         # Set numpy random state
-        self.random_state = np.random.RandomState()
+        self.random_state = np.random.RandomState(seed=numpy_seed)
         
         # Make sure that all variables initialized within ifs are defined
         self.rng = None


### PR DESCRIPTION
When making a `RandomNumbers` object, we had the option to set the seed only for the curand RNG through the `xorwow_seed` constructor parameter. 
This PR adds a general `seed` parameter to the constructor that also works for LCG, and which is used by curand if `xorwow_seed` is zero.

Tests are included.

Why not deprecate `xorwow_seed`? Because it might be allowed to use a list/array as `xorwow_seed` parameter, but that won't necessarily work for the numpy seeding. 