### PR TITLE
Bugfix to avoid `inf` as random normal distributed number

### DIFF
--- a/src/gpuocean/gpu_kernels/random_number_generators.cu
+++ b/src/gpuocean/gpu_kernels/random_number_generators.cu
@@ -74,7 +74,7 @@ __global__ void uniformDistribution(
         float* const random_row = (float*) ((char*) random_ptr_ + random_pitch_*tj);
         
         unsigned long long seed = seed_row[ti];
-        float2 u = ansic_lcg(&seed);
+        float2 u = rand_uniform(&seed);
 
         seed_row[ti] = seed;
 
@@ -116,8 +116,7 @@ __global__ void normalDistribution(
         float* const random_row = (float*) ((char*) random_ptr_ + random_pitch_*tj);
         
         unsigned long long seed = seed_row[ti];
-        float2 r = ansic_lcg(&seed);
-        float2 u = boxMuller(r);
+        float2 u = rand_normal(&seed);
 
         seed_row[ti] = seed;
 

--- a/src/gpuocean/gpu_kernels/random_number_generators.cu
+++ b/src/gpuocean/gpu_kernels/random_number_generators.cu
@@ -44,6 +44,10 @@ __device__ float2 boxMuller(float2 u) {
 }
 __device__ float2 rand_normal(unsigned long long* seed_ptr) {
     float2 u = ansic_lcg(seed_ptr);
+    if (u.x == 0.0) {
+        // u.x == 0.0 gives inf for normal distribution
+        u = ansic_lcg(seed_ptr);
+    }
     return boxMuller(u);
 }
 


### PR DESCRIPTION
The pseudo-random uniform distributed number produced by LCG for certain seeds (e.g. 1871412062) produces exactly 0.0. Although unlikely, this is fine in isolation. The problem occurs when this pseudo-random uniformly distributed number is used as the first argument to the Box-Muller algorithm to create normal distributed numbers. This argument `u.x` goes into `log(u.x)`, and we get infinity.

This PR adds a check to ensure that we never pass `u.x = 0.0` to Box-Muller, and instead sample a new uniform random number in this case.
Relevant unit test included, and some minor refactoring to only implement this test once.