### PR TITLE
Missing difter_t parameter

### DIFF
--- a/src/gpuocean/SWEsimulators/Simulator.py
+++ b/src/gpuocean/SWEsimulators/Simulator.py
@@ -127,6 +127,7 @@ class Simulator(object):
             
         self.hasDrifters = False
         self.drifters = None
+        self.drifter_t = self.t
 
         # Model error object
         self.model_error = None


### PR DESCRIPTION
Missing field which is set only in "attachDrifters". We need this parameter to be defined in order to run drift simulation based on a sim, but without attaching (which is nice for developing, debugging, benchmarking, etc)

Will merge directly.